### PR TITLE
Fixes time not passing when sleeping in CandyWorld

### DIFF
--- a/src/main/java/com/ochotonida/candymod/world/dimension/WorldProviderCandyWorld.java
+++ b/src/main/java/com/ochotonida/candymod/world/dimension/WorldProviderCandyWorld.java
@@ -1,19 +1,27 @@
 package com.ochotonida.candymod.world.dimension;
 
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.DimensionType;
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.gen.IChunkGenerator;
-
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.ochotonida.candymod.ModConfig;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.gen.IChunkGenerator;
+
 public class WorldProviderCandyWorld extends WorldProvider {
+	
+	private long worldTime = 0;
 
     @Override
     protected void init() {
         this.hasSkyLight = true;
         this.biomeProvider = new BiomeProviderCandyWorld(world.getWorldInfo());
+        NBTTagCompound nbttagcompound = this.world.getWorldInfo().getDimensionData(ModConfig.dimensionId);
+        this.worldTime = this.world instanceof WorldServer ? nbttagcompound.getLong("CandyTime") : 0;
     }
 
     @Override
@@ -43,5 +51,22 @@ public class WorldProviderCandyWorld extends WorldProvider {
     @ParametersAreNonnullByDefault
     public WorldSleepResult canSleepAt(net.minecraft.entity.player.EntityPlayer player, BlockPos pos) {
         return WorldSleepResult.ALLOW;
+    }
+    
+    @Override
+	public long getWorldTime(){
+        return this.worldTime;
+    }
+    
+    @Override
+	public void setWorldTime(long time){
+        this.worldTime = time;
+    }
+    
+    @Override
+	public void onWorldSave(){
+        NBTTagCompound nbttagcompound = new NBTTagCompound();
+        nbttagcompound.setLong("CandyTime", this.worldTime);
+        this.world.getWorldInfo().setDimensionData(ModConfig.dimensionId, nbttagcompound);
     }
 }


### PR DESCRIPTION
Allows for night to pass normally when sleeping in the candy dimension. Note, this fix does mean that the candy dimension and the overworld run on separate times (so it may be night in the overworld and daytime in the candy dimension). 